### PR TITLE
fix package deps

### DIFF
--- a/leibniz/info.rkt
+++ b/leibniz/info.rkt
@@ -1,11 +1,19 @@
 #lang info
 (define collection "leibniz")
-(define deps '("base"
-               "threading"
-               "rackunit-lib"
+(define deps '("at-exp-lib"
+               "base"
                "chk"
+               "drracket"
+               "functional-lib"
+               "gui-lib"
                "megaparsack"
-               "sxml"))
+               "net-lib"
+               "rackunit-lib"
+               "scribble-lib"
+               "sxml"
+               "threading"))
+(define build-deps '("racket-doc"
+                     "scribble-doc"))
 (define pkg-desc "Leibniz - A Digital Scientific Notation")
 (define version "0.2")
 


### PR DESCRIPTION
FYI, I was running `raco setup` for v6.9 and learned about these missing dependencies.

With this PR `raco setup --check-pkg-deps leibniz` is clean for me.